### PR TITLE
fix npm require

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ You can install Hashkit using npm:
 
 To use Hashkit on the server, require the file:
 
-    var Hashkit = require("./hashkit.js");
+    var Hashkit = require("hashkit");
 
 ### Browser
 

--- a/package.json
+++ b/package.json
@@ -7,5 +7,6 @@
         "hash", "shorten", "url", "integer", "encode", "decode"
     ],
     "repository": "https://github.com/mikecao/hashkit.git",
-    "license": "MIT"
+    "license": "MIT",
+    "main": "hashkit"
 }


### PR DESCRIPTION
As it is this module can't be npm installed and required like a normal node module. The problem is there is no index.js file and no `main` specified in package.json so node doesn't know where the entry point of the module is.

I've added the `main` property to package.json so it knows where the entry point is so it can easily be installed with npm and required from node. I've also updated the readme to use the fixed require syntax.

Thanks for writing this library, it's just what I need!
